### PR TITLE
Return a response from the server.js functions by default.

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -362,7 +362,7 @@ exports.kodiTestConnection = (request) => {
             resolve(result);
         })
         .catch((error) => {
-            console.log(`Failed to communicate with kodi. Error: ${error}`);
+            console.log(`Failed to communicate with kodi. Error: ${error.message}`);
             reject(error);
         });
     });

--- a/helpers.js
+++ b/helpers.js
@@ -22,7 +22,6 @@ exports.kodiPlayPause = (request, response) => { // eslint-disable-line no-unuse
     Kodi.Player.PlayPause({ // eslint-disable-line new-cap
         playerid: 1
     });
-    response.sendStatus(200);
 };
 
 exports.kodiStop = (request, response) => { // eslint-disable-line no-unused-vars
@@ -32,7 +31,6 @@ exports.kodiStop = (request, response) => { // eslint-disable-line no-unused-var
     Kodi.Player.Stop({ // eslint-disable-line new-cap
         playerid: 1
     });
-    response.sendStatus(200);
 };
 
 exports.kodiMuteToggle = (request, response) => { // eslint-disable-line no-unused-vars
@@ -42,7 +40,6 @@ exports.kodiMuteToggle = (request, response) => { // eslint-disable-line no-unus
     Kodi.Application.SetMute({ // eslint-disable-line new-cap
         'mute': 'toggle'
     });
-    response.sendStatus(200);
 };
 
 exports.kodiSetVolume = (request, response) => { // eslint-disable-line no-unused-vars
@@ -53,7 +50,6 @@ exports.kodiSetVolume = (request, response) => { // eslint-disable-line no-unuse
     Kodi.Application.SetVolume({ // eslint-disable-line new-cap
         'volume': parseInt(setVolume)
     });
-    response.sendStatus(200);
 };
 
 exports.kodiActivateTv = (request, response) => { // eslint-disable-line no-unused-vars
@@ -121,10 +117,9 @@ exports.kodiPlayMovie = (request, response) => { // eslint-disable-line no-unuse
     }).catch((error) => {
         console.log(error);
     });
-    response.sendStatus(200);
 };
 
-const kodiFindTvShow = (request, res, param) => {
+const kodiFindTvShow = (request, response, param) => {
     return new Promise((resolve, reject) => {
         let Kodi = request.kodi;
 
@@ -150,7 +145,7 @@ const kodiFindTvShow = (request, res, param) => {
     });
 };
 
-const kodiPlayNextUnwatchedEpisode = (request, res, RequestParams) => {
+const kodiPlayNextUnwatchedEpisode = (request, response, RequestParams) => {
     console.log(`Searching for next episode of Show ID ${RequestParams.tvshowid}...`);
     // Build filter to search unwatched episodes
     let param = {
@@ -177,7 +172,6 @@ const kodiPlayNextUnwatchedEpisode = (request, res, RequestParams) => {
                 console.log('found episodes..');
                 // Check whether we have seen this episode already
                 let firstUnplayedEpisode = episodes.filter((item) => {
-                    // FIXME: This is returned from an async method. So what's the use for this?
                     return item.playcount === 0;
                 });
 
@@ -199,7 +193,6 @@ const kodiPlayNextUnwatchedEpisode = (request, res, RequestParams) => {
         .catch((e) => {
             console.log(e);
         });
-    res.sendStatus(200);
 };
 
 exports.kodiPlayTvshow = (request, response) => { // eslint-disable-line no-unused-vars
@@ -215,7 +208,7 @@ exports.kodiPlayTvshow = (request, response) => { // eslint-disable-line no-unus
     });
 };
 
-const kodiPlaySpecificEpisode = (request, res, requestParams) => {
+const kodiPlaySpecificEpisode = (request, response, requestParams) => {
     console.log(`Searching Season ${requestParams.seasonNum}, episode ${requestParams.episodeNum} of Show ID ${requestParams.tvshowid}...`);
 
     // Build filter to search for specific season and episode number
@@ -260,7 +253,6 @@ const kodiPlaySpecificEpisode = (request, res, requestParams) => {
         .catch((e) => {
             console.log(e);
         });
-    res.sendStatus(200);
 };
 
 exports.kodiPlayEpisodeHandler = (request, response) => { // eslint-disable-line no-unused-vars
@@ -353,9 +345,8 @@ exports.kodiOpenTvshow = (request, response) => {
 };
 
 // Start a full library scan
-exports.kodiScanLibrary = (request, response) => {
+exports.kodiScanLibrary = (request, response) => { // eslint-disable-line no-unused-vars
     request.kodi.VideoLibrary.Scan(); // eslint-disable-line new-cap
-    response.sendStatus(200);
 };
 
 const tryPlayingChannelInGroup = (searchOptions, reqChannel, chGroups, currGroupI, Kodi) => {
@@ -442,7 +433,6 @@ const kodiPlayChannel = (request, response, searchOptions) => {
     }).catch((e) => {
         console.log(e);
     });
-
 };
 
 exports.kodiPlayChannelByName = (request, response) => { // eslint-disable-line no-unused-vars

--- a/helpers.js
+++ b/helpers.js
@@ -349,6 +349,25 @@ exports.kodiScanLibrary = (request, response) => { // eslint-disable-line no-unu
     request.kodi.VideoLibrary.Scan(); // eslint-disable-line new-cap
 };
 
+exports.kodiTestConnection = (request) => {
+    return new Promise((resolve, reject) => {
+        let param = {
+            title: 'Initiated by IFTTT',
+            message: 'Test Successful!'
+        };
+    
+        request.kodi.GUI.ShowNotification(param) // eslint-disable-line new-cap
+        .then((result) => {
+            console.log(`Test successful. result: ${result}`);
+            resolve(result);
+        })
+        .catch((error) => {
+            console.log(`Failed to communicate with kodi. Error: ${error}`);
+            reject(error);
+        });
+    });
+};
+
 const tryPlayingChannelInGroup = (searchOptions, reqChannel, chGroups, currGroupI, Kodi) => {
     if (currGroupI < chGroups.length) {
 

--- a/kodi-connection/api.js
+++ b/kodi-connection/api.js
@@ -1,6 +1,5 @@
 module.exports = function(fetch) {
   var namespaces = require('./api-methods.js');
-  var kodi_auth;
 
   function addMethods(obj) {
     namespaces.forEach(function(namespace) {
@@ -14,7 +13,7 @@ module.exports = function(fetch) {
   }
 
   function Kodi(ip, port, username, password) {
-    kodi_auth = 'Basic ' + new Buffer(username + ':' + password).toString('base64');
+    this.kodi_auth = 'Basic ' + new Buffer(username + ':' + password).toString('base64');
     this.url = 'http://' + ip + ':' + port + '/jsonrpc';
     addMethods(this);
   }
@@ -24,7 +23,7 @@ module.exports = function(fetch) {
     var headers = {
       "Content-type": "application/json",
       'Accept': "application/json",
-      'Authorization': kodi_auth
+      'Authorization': this.kodi_auth
     };
 
     return fetch(this.url, {
@@ -33,6 +32,9 @@ module.exports = function(fetch) {
         headers: headers
       })
       .then(function (response) {
+        if (response.status !== 200) {
+          throw new Error(`Error in response, ${response.statusText} with status code: ${response.status}`);
+        }
         return response.json();
       })
       .then(function(data) {

--- a/kodi-connection/api.js
+++ b/kodi-connection/api.js
@@ -1,3 +1,16 @@
+/**
+ * Custom response exception
+ * @param {*} message Exception message.
+ * @param {*} statusText Optional status text, retreived from the responses status text.
+ * @param {*} status Optional status response code.
+ */
+function ResponseException(message, statusText, status) {
+  this.message = message;
+  this.name = 'ResponseException';
+  this.statusText = statusText || this.message;
+  this.status = status || 400;
+}
+
 module.exports = function(fetch) {
   var namespaces = require('./api-methods.js');
 
@@ -33,7 +46,9 @@ module.exports = function(fetch) {
       })
       .then(function (response) {
         if (response.status !== 200) {
-          throw new Error(`Error in response, ${response.statusText} with status code: ${response.status}`);
+          throw new ResponseException(`Error in response, ${response.statusText} with status code: ${response.status}`,
+                                      response.statusText,
+                                      response.status);
         }
         return response.json();
       })

--- a/server.js
+++ b/server.js
@@ -51,6 +51,7 @@ app.all('/playpause', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiPlayPause(request, response);
     });
+    response.sendStatus(200);
 });
 
 // Stop video player
@@ -58,6 +59,7 @@ app.all('/stop', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiStop(request, response);
     });
+    response.sendStatus(200);
 });
 
 // Seek forward x seconds
@@ -65,6 +67,7 @@ app.all('/seekforward', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiSeek(request, response);
     });
+    response.sendStatus(200);
 });
 
 // mute or unmute kodi
@@ -72,6 +75,7 @@ app.all('/mute', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiMuteToggle(request, response);
     });
+    response.sendStatus(200);
 });
 
 // set kodi volume
@@ -79,6 +83,7 @@ app.all('/volume', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiSetVolume(request, response);
     });
+    response.sendStatus(200);
 });
 
 // Turn on TV and Switch to Kodi's HDMI input
@@ -86,6 +91,7 @@ app.all('/activatetv', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiActivateTv(request, response);
     });
+    response.sendStatus(200);
 });
 
 // Parse request to watch a movie
@@ -94,6 +100,7 @@ app.all('/playmovie', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiPlayMovie(request, response);
     });
+    response.sendStatus(200);
 });
 
 // Parse request to open a specific tv show
@@ -102,6 +109,7 @@ app.all('/opentvshow', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiOpenTvshow(request, response);
     });
+    response.sendStatus(200);
 });
 
 // Start a new library scan
@@ -109,6 +117,7 @@ app.all('/scanlibrary', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiScanLibrary(request, response);
     });
+    response.sendStatus(200);
 });
 
 // Parse request to watch your next unwatched episode for a given tv show
@@ -117,6 +126,7 @@ app.all('/playtvshow', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiPlayTvshow(request, response);
     });
+    response.sendStatus(200);
 });
 
 // Parse request to watch a specific episode for a given tv show
@@ -127,6 +137,7 @@ app.all('/playepisode', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiPlayEpisodeHandler(request, response);
     });
+    response.sendStatus(200);
 });
 
 // Parse request to Shutdown the kodi system
@@ -146,6 +157,7 @@ app.all('/shuffleepisode', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiShuffleEpisodeHandler(request, response);
     });
+    response.sendStatus(200);
 });
 
 // Parse request to watch a PVR channel by name
@@ -154,6 +166,7 @@ app.all('/playpvrchannelbyname', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiPlayChannelByName(request, response);
     });
+    response.sendStatus(200);
 });
 
 
@@ -165,6 +178,7 @@ app.all('/playyoutube', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiPlayYoutube(request, response);
     });
+    response.sendStatus(200);
 });
 
 // Parse request to watch a PVR channel by number
@@ -173,6 +187,7 @@ app.all('/playpvrchannelbynumber', function(request, response) {
     validateRequest(request, response).then(() => {
         Helper.kodiPlayChannelByNumber(request, response);
     });
+    response.sendStatus(200);
 });
 
 app.get('/', (request, response) => {

--- a/server.js
+++ b/server.js
@@ -190,6 +190,29 @@ app.all('/playpvrchannelbynumber', function(request, response) {
     response.sendStatus(200);
 });
 
+// Parse request to test the end2end kodi connectivity.
+// Request format:     http://[THIS_SERVER_IP_ADDRESS]/koditestconnection
+app.all('/koditestconnection', function(request, response) {
+    console.log('Request incomming for testing the end2end connectivity to kodi.');
+    validateRequest(request, response).then(() => {
+        Helper.kodiTestConnection(request, response)
+        .then(() => {
+            response.sendStatus(200);
+            console.log('Test seemed to successful, you should have seen a notification on your kodi GUI.');
+        })
+        .catch(error => { // eslint-disable-line arrow-parens
+            let status = 400;
+            const re = new RegExp('^.+([0-9]{3}$)', 'i');
+            const match = re.exec(error.message.trim());
+            
+            if (match) {
+                status = match.slice(-1)[0];
+            }
+            response.status(status).send(error.message);
+        });
+    });
+});
+
 app.get('/', (request, response) => {
     response.sendFile(`${__dirname}/views/index.html`);
 });

--- a/server.js
+++ b/server.js
@@ -202,11 +202,9 @@ app.all('/koditestconnection', function(request, response) {
         })
         .catch(error => { // eslint-disable-line arrow-parens
             let status = 400;
-            const re = new RegExp('^.+([0-9]{3}$)', 'i');
-            const match = re.exec(error.message.trim());
             
-            if (match) {
-                status = match.slice(-1)[0];
+            if (error.status) {
+                status = error.status;
             }
             response.status(status).send(error.message);
         });


### PR DESCRIPTION
Whe're not waiting for any result, and IFTTT also doesn't do anything with the response.
So until then, just return async.
Should fix #48 

Other features i've sneaked in here:
* fixed bug when using multiple kodi instances. Where the second password was overwriting the first one.
* New route /koditestconnection, which you can use to test the end2end connectivity with Kodi.
The route will also return the response code it got from kodi.
* Added some more debug logging, which should give you some info, if the connection with kodi is not working as expected.