### PR TITLE
added support for kodi-https configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Disclaimer: Use on your own risk and choose complex username & password in the b
 4. Change Glitch project settings to private (under *share* > *Make private*)
 5. Edit the *.env* file in your Glitch project with the following settings:
 ```
+KODI_PROTOCOL: "http"
 KODI_IP="YOUR_EXTERNAL_IP_ADDRESS"
 KODI_PORT="YOUR_KODI_PORT"
 KODI_USER="YOUR_KODI_USER_NAME"
@@ -199,6 +200,8 @@ For this you will need to extend the list. Like in this example:
 ```
 exports.kodiConfig = [{
     id: 'kodi', // For now leave the first set to kodi.
+    // YOUR_EXTERNAL_PROTOCOL (http or https)
+    kodiProtocol: 'http',
     // YOUR_KODI_IP_ADDRESS
     kodiIp: '192.168.178.10',
     // YOUR_KODI_PORT
@@ -212,6 +215,8 @@ exports.kodiConfig = [{
     // For example alternate kodi destination 1:   
 {
     id: 'bedroom',
+    // YOUR_EXTERNAL_PROTOCOL (http or https)
+    kodiProtocol: 'http',
     // YOUR_KODI_IP_ADDRESS
     kodiIp: '192.168.1.11',
     // YOUR_KODI_PORT
@@ -225,6 +230,8 @@ exports.kodiConfig = [{
     // For example alternate kodi destination 2:   
 {
     id: 'kitchen',
+    // YOUR_EXTERNAL_PROTOCOL (http or https)
+    kodiProtocol: 'http',
     // YOUR_KODI_IP_ADDRESS
     kodiIp: '192.168.1.12',
     // YOUR_KODI_PORT

--- a/config.js
+++ b/config.js
@@ -26,7 +26,12 @@ const Init = function() {
         this.kodiHosts = kodiConfig.map((config) => {
             return {
                 id: config.id,
-                host: new Kodi(config.kodiIp, config.kodiPort, config.kodiUser, config.kodiPassword)
+                host: new Kodi(
+                    config.kodiProtocol || 'http',
+                    config.kodiIp,
+                    config.kodiPort,
+                    config.kodiUser,
+                    config.kodiPassword)
             };
         });
         console.log(`Loaded ${this.kodiHosts.length} hosts from the config.js`);
@@ -38,7 +43,12 @@ const Init = function() {
 
         this.kodiHosts[0] = {
             id: 'kodi',
-            host: new Kodi(process.env.KODI_IP, process.env.KODI_PORT, process.env.KODI_USER, process.env.KODI_PASSWORD)
+            host: new Kodi(
+                process.env.KODI_PROTOCOL || 'http',
+                process.env.KODI_IP,
+                process.env.KODI_PORT,
+                process.env.KODI_USER,
+                process.env.KODI_PASSWORD)
         };
     }
 

--- a/helpers.js
+++ b/helpers.js
@@ -384,7 +384,7 @@ const kodiSeek = (Kodi, seekValue) => {
 
 const kodiExecuteMultipleTimes = (action, times) => {
 
-    let executions = [...Array(times)].map(() => action()); // eslint-disable-line new-cap
+    let executions = [...Array(times)].map(() => action());
 
     return Promise.all(executions);
 };

--- a/kodi-connection/api.js
+++ b/kodi-connection/api.js
@@ -14,9 +14,9 @@ module.exports = (fetch) => {
         });
     };
 
-    const Kodi = function(ip, port, username, password) {
+    const Kodi = function(protocol, ip, port, username, password) {
         this.kodiAuth = `Basic ${new Buffer(`${username}:${password}`).toString('base64')}`;
-        this.url = `http://${ip}:${port}/jsonrpc`;
+        this.url = `${protocol}://${ip}:${port}/jsonrpc`;
         addMethods(this);
     };
 

--- a/kodi-hosts.config.js.dist
+++ b/kodi-hosts.config.js.dist
@@ -1,5 +1,7 @@
 exports.kodiConfig = [{
     id: 'kodi', // For now leave the first set to kodi.
+    // YOUR_EXTERNAL_PROTOCOL (http or https)
+    kodiProtocol: 'http',
     // YOUR_EXTERNAL_IP_ADDRESS
     kodiIp: '192.168.1.17',
     // YOUR_KODI_PORT
@@ -10,7 +12,9 @@ exports.kodiConfig = [{
     kodiPassword: 'myKodiPassword'
 }
     // You can use this to specify additonal kodi installation, that you'd like to control.
-    // ,{id: 'bedroom', // For example the bedroom, will allow you to create IFTTT sentences like: `okay google bedroom play ..` 
+    // ,{id: 'bedroom', // For example the bedroom, will allow you to create IFTTT sentences like: `okay google bedroom play ..`
+    // YOUR_EXTERNAL_PROTOCOL (http or https)
+    // kodiProtocol: 'http',
     // // YOUR_EXTERNAL_IP_ADDRESS
     // kodiIp: '192.168.1.18',
     // // YOUR_KODI_PORT


### PR DESCRIPTION
your kodi instance can now still be configured,
when behind a https reverse proxy.

Resolves OmerTu/GoogleHomeKodi#23