### PR TITLE
Fix first video channel or playlist

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -971,8 +971,15 @@ exports.kodiPlayYoutube = (request, response) => { // eslint-disable-line no-unu
             if (!results || results.length === 0) {
                 reject('no results found');
             }
-
-            resolve(results[0]);
+        
+            results.forEach((result, index) => {
+              if(result.kind == 'youtube#video'){
+                resolve(result);
+                return;
+              }
+            });
+            
+            reject('no playable video found');
 
         })).then((foundVideo) => {
 


### PR DESCRIPTION
Fix issue where first video of youtube search was playlist or channel. Now when you say "youtube LinusTechTips" it plays latest video instead of failing.