### PR TITLE
Added support to play all episodes of a show in shuffle

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -67,7 +67,7 @@ const resumeTvShowEpisode = (request, episode) => {
     });
 };
 
-const playTvShowEpisodes = (request, episodes) => {
+const playTvShowEpisodes = (request, episodes, isShuffled = false) => {
 
     let kodi = request.kodi;
     let items = episodes.map((episode) => ({
@@ -84,7 +84,12 @@ const playTvShowEpisodes = (request, episodes) => {
     .then(() => kodi.Player.Open({ // eslint-disable-line new-cap
         item: {
             playlistid: VIDEO_PLAYER
+        },
+        options: {
+            shuffled: isShuffled
         }
+    })).then(() => kodi.GUI.SetFullscreen({
+        fullscreen: true
     }));
 };
 
@@ -965,6 +970,17 @@ exports.kodiShuffleEpisodeHandler = (request, response) => { // eslint-disable-l
         .then((tvShow) => kodiGetTvShowsEpisodes(request, tvShow))
         .then((episodes) => selectRandomItem(episodes))
         .then((episode) => playTvShowEpisode(request, episode));
+};
+
+exports.kodiShuffleShowHandler = (request, response) => { // eslint-disable-line no-unused-vars
+    tryActivateTv(request, response);
+    let tvShowTitle = request.query.q;
+
+    console.log(`A shuffle show request received to play for show ${tvShowTitle}`);
+
+    return kodiFindTvShow(request, tvShowTitle)
+        .then((tvShow) => kodiGetTvShowsEpisodes(request, tvShow))
+        .then((episodes) => playTvShowEpisodes(request, episodes, true));
 };
 
 exports.kodiOpenTvshow = (request) => {

--- a/server.js
+++ b/server.js
@@ -151,6 +151,9 @@ app.all('/suspend', exec(Helper.kodiSuspend));
 // http://1.1.1.1/playepisode?q=bla+season+2+episode&e=3
 app.all('/shuffleepisode', exec(Helper.kodiShuffleEpisodeHandler));
 
+// Parse request to watch all episodes of a show on shuffle
+app.all('/shuffleshow', exec(Helper.kodiShuffleShowHandler));
+
 // Parse request to watch a PVR channel by name
 // Request format:     http://[THIS_SERVER_IP_ADDRESS]/playpvrchannelbyname?q=[CHANNEL_NAME]
 app.all('/playpvrchannelbyname', exec(Helper.kodiPlayChannelByName));


### PR DESCRIPTION
Sometimes binge watching is better when shuffled.

Also, I found that `playTvShowEpisodes` would often result in the Player playing in the background (rendering behind the UI). To resolve this, I added a call to `kodi.GUI.SetFullscreen` to make sure that the Player is focused after loading and playing the new playlist.