### PR TITLE
updated seektominutes command with proper HH:MM:SS format

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1118,3 +1118,11 @@ exports.kodiTogglePartymode = (request) => {
         .catch(() => AUDIO_PLAYER)
         .then((playerid) => togglePartyMode(kodi, playerid));
 };
+
+exports.kodiToggleFullscreen = (request) => { // eslint-disable-line no-unused-vars
+    console.log('Toggle Fullscreen request received');
+    let Kodi = request.kodi;
+    return Kodi.Input.ExecuteAction({
+		'action': 'togglefullscreen'
+	});
+};

--- a/helpers.js
+++ b/helpers.js
@@ -665,8 +665,13 @@ exports.kodiSeektominutes = (request, response) => { // eslint-disable-line no-u
 
     const seektominutes = request.query.q.trim();
 
+    let hours = parseInt(seektominutes / 60);
+    let minutes = parseInt(seektominutes % 60);
+
     return kodiSeek(Kodi, {
-        minutes: parseInt(seektominutes)
+    	hours: hours,
+	    minutes: minutes,
+	    seconds: 0
     });
 };
 

--- a/server.js
+++ b/server.js
@@ -251,6 +251,8 @@ app.all('/playgenre', exec(Helper.kodiPlayMusicByGenre));
 
 app.all('/togglePartymode', exec(Helper.kodiTogglePartymode));
 
+app.all('/toggleFullscreen', exec(Helper.kodiToggleFullscreen));
+
 // Playlist Control
 app.all('/playercontrol', exec(Helper.playercontrol));
 


### PR DESCRIPTION
Fix for #169.

I noticed today that the seektominutes command can't seek more than 59 minutes. This is due to the way Kodi's Player.Seek function handles time requests and needs to be provided a HH:MM:SS (hours, minutes, seconds) format. The seektominutes command currently only provides a minutes value and it's not sufficient for the seeking function to work properly.

To fix the issue, I edited the helper.js file with the following code:

Replaced lines 668 to 670
```
return kodiSeek(Kodi, {
	minutes: parseInt(seektominutes)
});
```
With the code below
```
let hours = parseInt(seektominutes / 60);
let minutes = parseInt(seektominutes % 60);
return kodiSeek(Kodi, {
	hours: hours,
	minutes: minutes,
	seconds: 0
});
```