### PR TITLE
updated kodiSeektominutes with proper HH:MM:SS format

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -665,8 +665,13 @@ exports.kodiSeektominutes = (request, response) => { // eslint-disable-line no-u
 
     const seektominutes = request.query.q.trim();
 
+   	let hours = parseInt(seektominutes / 60);
+   	let minutes = parseInt(seektominutes % 60);
+
     return kodiSeek(Kodi, {
-        minutes: parseInt(seektominutes)
+       	hours: hours,
+       	minutes: minutes,
+       	seconds: 0
     });
 };
 


### PR DESCRIPTION
Fix for #169 

I noticed today that the seektominutes command can't seek more than 59 minutes. This is due to the way Kodi's Player.Seek function handles time requests and needs to be provided a HH:MM:SS (hours, minutes, seconds) format. The seektominutes command currently only provides a minutes value and it's not sufficient for the seeking function to work properly.

To fix the issue, I edited the helper.js file with the following code:

Replace lines 668 to 670
```
return kodiSeek(Kodi, {
	minutes: parseInt(seektominutes)
});
```
With the code below
```
let hours = parseInt(seektominutes / 60);
let minutes = parseInt(seektominutes % 60);
return kodiSeek(Kodi, {
	hours: hours,
	minutes: minutes,
	seconds: 0
});
```