### PR TITLE
added support to toggle fullscreen mode

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1113,3 +1113,11 @@ exports.kodiTogglePartymode = (request) => {
         .catch(() => AUDIO_PLAYER)
         .then((playerid) => togglePartyMode(kodi, playerid));
 };
+
+exports.kodiToggleFullscreen = (request) => { // eslint-disable-line no-unused-vars
+    console.log('Toggle Fullscreen request received');
+    let Kodi = request.kodi;
+    return Kodi.Input.ExecuteAction({
+		'action': 'togglefullscreen'
+	});
+};

--- a/server.js
+++ b/server.js
@@ -251,6 +251,8 @@ app.all('/playgenre', exec(Helper.kodiPlayMusicByGenre));
 
 app.all('/togglePartymode', exec(Helper.kodiTogglePartymode));
 
+app.all('/toggleFullscreen', exec(Helper.kodiToggleFullscreen));
+
 // Playlist Control
 app.all('/playercontrol', exec(Helper.playercontrol));
 


### PR DESCRIPTION
Fix for #166 

Kodi has a togglefullscreen function, but it wasn't implemented yet with GoogleHomeKodi.

I added the code below to server.js to make it work:
```
app.all('/toggleFullscreen', exec(Helper.kodiToggleFullscreen));
```
I also added this code to helpers.js:
```
exports.kodiToggleFullscreen = (request) => { // eslint-disable-line no-unused-vars
    console.log('Toggle Fullscreen request received');
    let Kodi = request.kodi;
    return Kodi.Input.ExecuteAction({
	'action': 'togglefullscreen'
    });
};
```