### PR TITLE
added ACTIVATE_TV variable for home servers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,8 +500,11 @@ To **Turn on/off the TV and switch Kodi's HDMI input**
     * Turn on: Add another command: follow the same instructions as *pause* but use this URL:
     >_YOUR_NODE_SERVER_/activatetv
     
-    *  Add the following line to your .env file (see step B.1 - (5) above) and kodi will automaticly turn on the tv and switch the HDMI input everytime your trigger the main playing actions (play a move / tv show / episode / pvr channel)
+    *  If host your server on Glitch, add the following line to your .env file (see step B.1 - (5) above) and kodi will automaticly turn on the tv and switch the HDMI input everytime your trigger the main playing actions (play a move / tv show / episode / pvr channel)
     >ACTIVATE_TV="true"
+    
+    *  If you host your server yourself (see step B.2 - (7) above), then add the following line at the end of your kodi-hosts.config.js file instead
+    >process.env['ACTIVATE_TV'] = 'true';
 
     * Turn off: Add another command: follow the same instructions as pause but use this URL:
     >_YOUR_NODE_SERVER_/standbytv


### PR DESCRIPTION
Fix for #168 

The ACTIVATE_TV="true" variable only works on Glitch when you have an .env file. People with home servers use kodi-hosts.config.js and the variable is declared a different way.

I updated the documentation accordingly for people who run home servers with this line of code:
```
process.env['ACTIVATE_TV'] = 'true';
```