### PR TITLE
Add optional delay parameter to movie and tv episode playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,11 +441,11 @@ For **PVR TV support - Set channel by number**, use "Say a phrase with a number"
 ## Full table with available actions
 | Type of phrase                                        | phrase                          | url                                                                       |
 |-------------------------------------------------------|---------------------------------|---------------------------------------------------------------------------|
-| Say a phrase with a text ingredient                   | Kodi play $                     | _YOUR_NODE_SERVER_/playmovie?q={{TextField}}                      |
-| Say a phrase with a text ingredient                   | Kodi resume $                   | _YOUR_NODE_SERVER_/resumemovie?q={{TextField}}                    |
-| Say a phrase with a text ingredient                   | Kodi play a random [$] movie [of year #]| _YOUR_NODE_SERVER_/playrandommovie?genre={{TextField}}&year={{NumberField}} |
-| Say a phrase with a text ingredient                   | Kodi play an episode of $       | _YOUR_NODE_SERVER_/playtvshow?q={{TextField}}                     |
-| Say a phrase with a text ingredient                   | Kodi resume an episode of $     | _YOUR_NODE_SERVER_/resumetvshow?q={{TextField}}                   |
+| Say a phrase with a text ingredient                   | Kodi play $                     | _YOUR_NODE_SERVER_/playmovie?q={{TextField}}  *delay                                        |
+| Say a phrase with a text ingredient                   | Kodi resume $                   | _YOUR_NODE_SERVER_/resumemovie?q={{TextField}}  *delay                                      |
+| Say a phrase with a text ingredient                   | Kodi play a random [$] movie [of year #]| _YOUR_NODE_SERVER_/playrandommovie?genre={{TextField}}&year={{NumberField}}  *delay |
+| Say a phrase with a text ingredient                   | Kodi play an episode of $       | _YOUR_NODE_SERVER_/playtvshow?q={{TextField}}  *delay                                       |
+| Say a phrase with a text ingredient                   | Kodi resume an episode of $     | _YOUR_NODE_SERVER_/resumetvshow?q={{TextField}}  *delay                                     |
 | Say a phrase with a text ingredient                   | Kodi binge watch $              | _YOUR_NODE_SERVER_/bingewatchtvshow?q={{TextField}}               |
 | Say a phrase with both a number and a text ingredient | Kodi play $ episode #           | _YOUR_NODE_SERVER_/playepisode?q={{TextField}}&e= {{NumberField}} |
 | Say a simple phrase                                   | Kodi play new episode           | _YOUR_NODE_SERVER_/playrecentepisode                              |
@@ -494,6 +494,12 @@ For **PVR TV support - Set channel by number**, use "Say a phrase with a number"
 | Say a phrase with a text ingredient                   | Kodi open $ from my favourites  | _YOUR_NODE_SERVER_/playfavourite?q={{TextField}}                   |
 | Say a simple phrase                                   | Kodi toggle fullscreen          | _YOUR_NODE_SERVER_/togglefullscreen                                |
 | Say a phrase with a text ingredient			| Kodi load profile $		  | _YOUR_NODE_SERVER_/loadProfile                                     |
+
+To **Start/resume a movie/tv episode with a delay**
+  The commands marked with *delay (above) take an optional delay parameter to delay startup of the media by the specified number of seconds.
+
+  For example:  
+YOUR_NODE_SERVER_/playmovie?q=Deadpool&delay=10
 
 To **Turn on/off the TV and switch Kodi's HDMI input**
   * This requires Kodi 17 (Krypton) and above

--- a/helpers.js
+++ b/helpers.js
@@ -910,33 +910,41 @@ exports.kodiPlayRandomMovie = (request, response) => { // eslint-disable-line no
 };
 
 exports.kodiPlayMovie = (request, response) => {
+    var sleep = require('sleep'); 
     tryActivateTv(request, response);
 
     let movieTitle = request.query.q;
+    let seconds = request.query.delay !== undefined ? parseInt(request.query.delay) : 0;
     let Kodi = request.kodi;
 
     console.log(`Movie request received to play "${movieTitle}"`);
+    sleep.sleep(seconds);
     return kodiFindMovie(movieTitle, Kodi)
         .then((movie) => playMovie(request, movie));
 };
 
 exports.kodiResumeMovie = (request, response) => {
+    var sleep = require('sleep'); 
     tryActivateTv(request, response);
 
     let movieTitle = request.query.q;
+    let seconds = request.query.delay !== undefined ? parseInt(request.query.delay) : 0;
     let Kodi = request.kodi;
 
     console.log(`Movie request received to resume "${movieTitle}"`);
+    sleep.sleep(seconds);
     return kodiFindMovie(movieTitle, Kodi)
         .then((movie) => resumeMovie(request, movie));
 };
 
 exports.kodiPlayTvshow = (request, response) => { // eslint-disable-line no-unused-vars
+    var sleep = require('sleep'); 
     tryActivateTv(request, response);
     let tvshowTitle = request.query.q;
+    let seconds = request.query.delay !== undefined ? parseInt(request.query.delay) : 0;
 
     console.log(`TV Show request received to play "${tvshowTitle}"`);
-
+    sleep.sleep(seconds);
     return kodiFindTvShow(request, tvshowTitle)
         .then((tvShow) => kodiGetTvShowsEpisodes(request, tvShow))
         .then((episodes) => selectFirstUnwatchedEpisode(episodes))
@@ -944,11 +952,12 @@ exports.kodiPlayTvshow = (request, response) => { // eslint-disable-line no-unus
 };
 
 exports.kodiResumeTvshow = (request, response) => { // eslint-disable-line no-unused-vars
+    var sleep = require('sleep'); 
     tryActivateTv(request, response);
     let tvshowTitle = request.query.q;
-
+    let seconds = request.query.delay !== undefined ? parseInt(request.query.delay) : 0;
     console.log(`TV Show request received to resume "${tvshowTitle}"`);
-
+    sleep.sleep(seconds);
     return kodiFindTvShow(request, tvshowTitle)
         .then((tvShow) => kodiGetTvShowsEpisodes(request, tvShow))
         .then((episodes) => selectFirstUnwatchedEpisode(episodes))


### PR DESCRIPTION
I've added an optional (defaults to zero if not specified) parameter to play/resume tv/movies.  I use this in some of my IFTTT applets that perform multiple actions (from platform.ifttt).  For example I have a command that will turn on my home theater projector, and then start the desired media.  It takes about 20-30 seconds for my projector to start up, so new delay parameter is useful in that case.

The code depends upon the "sleep" npm, but that is already marked as a pre-requisite.  