### PR TITLE
Update server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,7 +29,11 @@ const handleError = (error, request, response, next) => { // eslint-disable-line
     try {
         let userRequest = request.query ? request.query.q : '';
         Helper.kodiShowError(request, response, userRequest + ': ' + publicError);
-    } catch {
+    }
+    
+    catch(err)
+    
+    {
         // swallow early error handling error
     }
 


### PR DESCRIPTION
Fixed syntax error raised by unexpected '(' in the "catch"  instruction (lines 32 to 40)