### PR TITLE
Suppress accent from phrase on Broker endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Control Kodi through your Google Home / Google Assistant
 - [What it can do](#what-it-can-do)
 - [How to setup and update](#how-to-setup-and-update)
 - [Full table with available actions](#full-table-with-available-actions)
-- [Testing](#testing)
+- [Testing language files](#testing-language-files)
 - [Troubleshooting](#troubleshooting)
 
 ------------

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Control Kodi through your Google Home / Google Assistant
 - [What it can do](#what-it-can-do)
 - [How to setup and update](#how-to-setup-and-update)
 - [Full table with available actions](#full-table-with-available-actions)
+- [Testing](#testing)
 - [Troubleshooting](#troubleshooting)
 
 ------------
@@ -181,8 +182,14 @@ KODI_PORT="YOUR_KODI_PORT"
 KODI_USER="YOUR_KODI_USER_NAME"
 KODI_PASSWORD="YOUR_KODI_PASSWORD"
 AUTH_TOKEN="YOUR_CONNECTION_PASSWORD"
+BROKER_ACCENT_INSENSITIVE_MATCH="true"
+BROKER_LANGUAGE_CACHE_ENABLE="false"
 ```
 *YOUR_CONNECTION_PASSWORD* can be anything you want.
+*BROKER_ACCENT_INSENSITIVE_MATCH* is a boolean value indicating if broker should do accent insensitive pattern matching (default: false).
+If set to true, broker will convert accentued characters from the sent phrase and the configured pattern in `<lang_code>.json` (for example `é`, `è`, `ê` and `ë`) to the unaccentued equivalent character (for example `e`).
+This allow to configure pattern `regarde` in `<lang_code>.json` and match `regarde`, `regardé`.
+*BROKER_LANGUAGE_CACHE_ENABLE* is a boolean value indicating if broker should can cache language file if previous and actual request language are equals (default: true).
 
 8. Check your Glitch server address by choosing 'Show Live' on the top left. A new tab with your server will open. Note your server address in the address bar, you will need that later. We will refer to this address as _YOUR_NODE_SERVER_. (i.e. https://green-icecream.glitch.me)
 
@@ -283,6 +290,8 @@ You can configure your instance simply through *environment variables* or a `kod
         -e KODI_USER="YOUR_KODI_USER_NAME" \
         -e KODI_PASSWORD="YOUR_KODI_PASSWORD" \
         -e AUTH_TOKEN="YOUR_CONNECTION_PASSWORD" \
+        -e BROKER_ACCENT_INSENSITIVE_MATCH="false" \
+        -e BROKER_LANGUAGE_CACHE_ENABLE="true" \
         --name googlehomekodi \
         omertu/googlehomekodi
      ```
@@ -302,6 +311,8 @@ You can configure your instance simply through *environment variables* or a `kod
             - KODI_USER=YOUR_KODI_USER_NAME
             - KODI_PASSWORD=YOUR_KODI_PASSWORD
             - AUTH_TOKEN=YOUR_CONNECTION_PASSWORD
+            - BROKER_ACCENT_INSENSITIVE_MATCH=true
+            - BROKER_LANGUAGE_CACHE_ENABLE=false
           restart: always
      ```  
      and then just fire it up with  
@@ -518,6 +529,7 @@ For **PVR TV/radio support - Set channel by number**, use "Say a phrase with a n
  If you want to use other language than english, just lang parameter to that URL:
  >_YOUR_NODE_SERVER_/broker?phrase={{TextField}}&lang=<lang_code>
 
+
  where <lang_code> is name of json file in app's _broker_ folder without json extension (so for example "lang=en")
 
  If there is not your language in _broker_ folder yet, it is easy to add a new language. Just copy en.json and name it with your language's code.
@@ -625,6 +637,39 @@ To **Turn on/off the TV and switch Kodi's HDMI input**
     * Turn off: Add another command: follow the same instructions as pause but use this URL:
     >_YOUR_NODE_SERVER_/standbytv
 
+------------
+## Testing language files
+When testing language files present in `test/broker/<lang_code>.json,` you can define a `config` key used when handling the request.
+
+The config key can be defined for the entire endpoint :
+```javascript
+  {
+    "endpoint": "kodiPlayTvChannelByName",
+    "phrases": [
+      // config is inherited from endpoint
+      { "phrase": "change la télé sur m6", "q": "m6" },
+    ],
+    "config": {
+      "brokerAccentInsensitiveMatch": true
+      "brokerLanguageCacheEnable": false
+    }
+  }
+```
+
+The config key can also be defined for a given phrase and take precedence on endpoint config :
+```javascript
+  {
+    "endpoint": "kodiPlayTvChannelByName",
+    "phrases": [
+      // config from phrase overrides endpoint config
+      { "phrase": "change la télé sur m6", "q": "m6", "config": { "brokerAccentInsensitiveMatch": false },
+    ],
+    "config": {
+      "brokerAccentInsensitiveMatch": true
+      "brokerLanguageCacheEnable": false
+    }
+  }
+```
 
 ------------
 ## Troubleshooting

--- a/broker.js
+++ b/broker.js
@@ -3,6 +3,7 @@
 const Helper = require('./helpers.js');
 const path = require('path');
 const fs = require('fs');
+const accents = require('remove-accents');
 
 let lastUsedLanguage = ``;
 let localizedPhrases = null;
@@ -61,6 +62,7 @@ const matchPhraseToEndpoint = (request) => {
     }
 
     let phrase = request.query.phrase.toLowerCase().trim();
+    phrase = accents.remove(phrase);
     let language = request.query.lang || `en`;
 
     if (lastUsedLanguage !== language) {

--- a/broker.js
+++ b/broker.js
@@ -62,20 +62,33 @@ const matchPhraseToEndpoint = (request) => {
     }
 
     let phrase = request.query.phrase.toLowerCase().trim();
-    phrase = accents.remove(phrase);
+    // Replace multiple space with single space.
+    phrase = phrase.replace(/\s\s+/g, ' ');
+
+    if (request.config?.brokerAccentInsensitiveMatch) {
+        phrase = accents.remove(phrase);
+    }
+
     let language = request.query.lang || `en`;
 
-    if (lastUsedLanguage !== language) {
-        // reload lang file if language has changed
+    if (request.config?.brokerLanguageCacheEnable === false || lastUsedLanguage !== language) {
+        // reload lang file if caching is disabled or language has changed
         localizedPhrases = loadLanguageFile(language);
-        lastUsedLanguage = language;
     }
+
+    lastUsedLanguage = language;
 
     console.log(`Broker processing phrase: '${phrase}' (${language})`);
 
     for (let key in localizedPhrases) {
 
-        let match = phrase.match(`^${localizedPhrases[key]}`);
+        let localizedPhrase = localizedPhrases[key];
+
+        if (request.config?.brokerAccentInsensitiveMatch) {
+            localizedPhrase = accents.remove(localizedPhrase);
+        }
+
+        let match = phrase.match(`^${localizedPhrase}`);
 
         if (match) {
 

--- a/config.js
+++ b/config.js
@@ -74,6 +74,8 @@ const Init = function() {
         this.globalConf.authToken = process.env.AUTH_TOKEN;
         this.globalConf.listenerPort = process.env.PORT;
         this.globalConf.youtubeKey = process.env.YOUTUBE_KEY || 'AIzaSyBYKxhPJHYUnzYcdOAv14Gmq-43_W9_79w';
+        this.globalConf.brokerAccentInsensitiveMatch = process.env.BROKER_ACCENT_INSENSITIVE_MATCH === 'true' ? true : false;
+        this.globalConf.brokerLanguageCacheEnable = process.env.BROKER_LANGUAGE_CACHE_ENABLE === 'false' ? false : true;
         console.log('Loaded config from .env (environment)');
     }
 

--- a/kodi-hosts.config.js.dist
+++ b/kodi-hosts.config.js.dist
@@ -31,5 +31,14 @@ exports.globalConfig = {
     // YOUR_LOCAL_LISTENING_PORT
     listenerPort: '8099',
     // YOUR_YOUTUBE_API_KEY
-    youtubeKey: 'AIzaSyBYKxhPJHYUnzYcdOAv14Gmq-43_W9_79w'
+    youtubeKey: 'AIzaSyBYKxhPJHYUnzYcdOAv14Gmq-43_W9_79w',
+    // Configure how broker handle accents in phrase matching.
+    // Set to `true` to enable accent insensitive matching or `false` to enable accent sensitive matching.
+    // Can be configure by environment variable BROKER_ACCENT_INSENSITIVE_MATCH
+    brokerAccentInsensitiveMatch: false,
+    // Configure how broker caches language file.
+    // Set to `true` to use previously loaded language file if previous and actual request language are equals
+    // or to `false` to force broker to reload language file on every request.
+    // Can be configure by environment variable BROKER_LANGUAGE_CACHE_ENABLE
+    brokerLanguageCacheEnable: true
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "fuse.js": "^5.2.1",
     "node-fetch": "^2.6.0",
     "words-to-numbers": "^1.5.1",
-    "youtube-search": "^1.1.4"
+    "youtube-search": "^1.1.4",
+    "remove-accents": "^0.4.2"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",

--- a/test/broker/generateTests.js
+++ b/test/broker/generateTests.js
@@ -45,6 +45,12 @@ const testBroker = function(language) {
                 endpointTest.phrases.forEach(function(phraseTest) {
                     it(phraseTest.phrase, function(done) {
                         this.testRequest.query.phrase = phraseTest.phrase;
+                        
+                        // Set or clear configuration for the phrase
+                        this.testRequest.config = endpointTest.config !== undefined || phraseTest.config !== undefined
+                            ? {...endpointTest.config, ...phraseTest.config}
+                            : undefined;
+                        
                         testSimplePhrase(this.testRequest, this.testResponse, endpointTest.endpoint, phraseTest.q, done);
                     });
                 });


### PR DESCRIPTION
Hi everyone,

For french speakers, it can be unreadable to implement complexe regex matching for broker due to accentued characters (for example, the action "play" will be "regard(e|é)".
This PR implements the phrase normalization by removing the accents to convert "regardé" --> "regarde".